### PR TITLE
Minor fix in `group_hydr_values()`

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -419,7 +419,10 @@ prepare_plant_parameter <- function(par_tbl) {
 #'
 group_hydr_values <- function(par_name, model_path) {
   hyd_hyd <- read_tbl(paste0(model_path, '/hydrology.hyd'))
-
+  # if there is an empty line at the end of the hydrology.hyd file, this
+  # function fails. Adding this filter makes sure that only rows with real data
+  # are loaded, as these should all be prefixed with "hyd" in the name column.
+  hyd_hyd %>% filter(grepl(x = name, pattern = "hyd")) -> hyd_hyd
   unique_values <- sort(unique(hyd_hyd[[par_name]]))
   value_group <- map_int(hyd_hyd[[par_name]], ~ which(.x == unique_values))
   unique_values <- paste(paste0(1:length(unique_values), ' = ', unique_values), collapse = ', ')


### PR DESCRIPTION
In the function:

```
perco_groups <- group_hydr_values('perco',   model_path)
```

The following error is produced:

```
Error in `map_int()`:
ℹ In index: 6207.
Caused by error:
! Result must be length 1, not 0.
Run `rlang::last_trace()` to see where the error occurred.
```

Because the last line of my hydrology.hyd is empty (idk why, but it is).

<img width="830" height="102" alt="Image" src="https://github.com/user-attachments/assets/be3b977f-9220-4f44-b34a-8fd551b4ca88" />

I would suggest adding this line of code in the `group_hydr_values()` to fix this edge case.

