### PR TITLE
Workflow adjustment

### DIFF
--- a/inst/extdata/wf_hardcal/03_run_swat.R
+++ b/inst/extdata/wf_hardcal/03_run_swat.R
@@ -26,7 +26,7 @@ n_cores <- NULL
 # Name of the folder where simulation results will be saved incrementally.
 # To continue writing to existing saved runs, replace by the name of the
 # existing save_file.
-save_file_name <- paste0(format(Sys.time(), '%Y%m%d%H%M'), '_sim')
+save_file_name <- paste0(format(Sys.time(), '%Y%m%d%H%M%S'), '_sim')
 
 # Path where the simulation results are saved.
 # Default the simulations are saved in the calibration project

--- a/inst/extdata/wf_hardcal/04_analyze_results.R
+++ b/inst/extdata/wf_hardcal/04_analyze_results.R
@@ -116,7 +116,7 @@ plot_parameter_identifiability(parameters = par_vals,
 # to plot dotty plots. Here is just one example, to get a full picture of
 # how to update parameter ranges the assessment of multiple dotty plots may
 # be neccesary.
-plot_dotty(par = parameter, gof_all$nse_q, n_col = 5)
+plot_dotty(par = par_vals, gof_all$nse_q, n_col = 5)
 
 # If the model performance must be improved and e.g. the parameter
 # identifiability plot clearly suggests to update parameter ranges for relevant


### PR DESCRIPTION
- Fixed an incorrect variable name in the workflow template
- Also I would add seconds to the save name, otherwise there is an error if a user tries to restart a new run in the same minute (might happen if SWAT+ is crashing due to unrealistic parameter changes -- which is currently what is happening to me!)